### PR TITLE
Add SO build targets for SQLite extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for go-sqlite-regexp
 
-.PHONY: all build test test-race test-cover clean examples help tag-major tag-minor tag-patch release
+.PHONY: all build test test-race test-cover clean examples help tag-major tag-minor tag-patch release so so-linux so-darwin
 
 # Default target
 all: test build
@@ -71,6 +71,18 @@ docs:
 	@echo "Generating documentation..."
 	@go doc -all .
 
+# Build loadable SQLite extension (.so/.dylib) using c-shared
+# Output goes to dist/regexp.$(EXT)
+so: so-linux
+
+so-linux:
+	@echo "Building SQLite loadable extension for Linux (.so)..."
+	@CGO_ENABLED=1 go build -buildmode=c-shared -o regexp.so ./extension
+
+so-darwin:
+	@echo "Building SQLite loadable extension for macOS (.dylib)..."
+	@CGO_ENABLED=1 go build -buildmode=c-shared -o regexp.dylib ./extension
+
 # Check for security vulnerabilities
 security:
 	@echo "Checking for security vulnerabilities..."
@@ -110,6 +122,9 @@ help:
 	@echo "  tidy       - Tidy dependencies"
 	@echo "  deps       - Install dependencies"
 	@echo "  docs       - Generate documentation"
+	@echo "  so         - Build loadable SQLite extension for current OS"
+	@echo "  so-linux   - Build .so extension (Linux)"
+	@echo "  so-darwin  - Build .dylib extension (macOS)"
 	@echo "  security   - Check for security vulnerabilities"
 	@echo "  ci         - Run full CI pipeline"
 	@echo "  tag-major  - Tag a new major version"

--- a/README.md
+++ b/README.md
@@ -232,6 +232,36 @@ go build -o myapp main.go
 CGO_ENABLED=1 go build -ldflags '-extldflags "-static"' -o myapp main.go
 ```
 
+### Build a loadable SQLite extension (.so/.dylib)
+
+This repository can also produce a SQLite loadable extension that exposes a `regexp(text, pattern)` function for use in the `sqlite3` CLI or any SQLite embedding that supports extension loading.
+
+Build on Linux:
+
+```bash
+make so-linux
+# outputs: ./regexp.so
+```
+
+Build on macOS:
+
+```bash
+make so-darwin
+# outputs: ./regexp.dylib
+```
+
+Load in the SQLite CLI:
+
+```sql
+-- in sqlite3 shell
+.load ./regexp      -- sqlite will add the correct extension suffix
+SELECT 'hello' REGEXP 'h.llo';
+```
+
+Note:
+- Your sqlite3 must be built with extension loading enabled.
+- The extension is built with `-buildmode=c-shared` and uses Go's RE2 engine; behavior matches the Go package.
+
 ### Docker
 
 Use a base image with build tools:

--- a/extension/main_dummy.go
+++ b/extension/main_dummy.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/extension/regexp_extension.c
+++ b/extension/regexp_extension.c
@@ -1,0 +1,32 @@
+#include <sqlite3ext.h>
+#include <stdlib.h>
+#include "regexp_extension.h"
+SQLITE_EXTENSION_INIT1
+
+// Forward declarations for Go
+extern void go_regexp(sqlite3_context *ctx, int argc, sqlite3_value **argv);
+extern int go_register_regexp(sqlite3* db);
+
+// Helper to index argv
+sqlite3_value* value_at(sqlite3_value **argv, int idx) { return argv[idx]; }
+const unsigned char* value_text(sqlite3_value* v) { return sqlite3_value_text(v); }
+void result_null(sqlite3_context* ctx) { sqlite3_result_null(ctx); }
+void result_error(sqlite3_context* ctx, const char* msg) { sqlite3_result_error(ctx, msg, -1); }
+void result_int(sqlite3_context* ctx, int v) { sqlite3_result_int(ctx, v); }
+
+// C-visible trampoline that calls into Go implementation
+static void call_go_regexp(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
+    go_regexp(ctx, argc, argv);
+}
+
+// Helper to register the function with SQLite
+int create_regexp(sqlite3* db) {
+    return sqlite3_create_function(db, "regexp", 2, SQLITE_UTF8, NULL, call_go_regexp, NULL, NULL);
+}
+
+int sqlite3_regexp_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi) {
+    SQLITE_EXTENSION_INIT2(pApi);
+    return go_register_regexp(db);
+}
+
+

--- a/extension/regexp_extension.go
+++ b/extension/regexp_extension.go
@@ -1,0 +1,58 @@
+package main
+
+// #cgo pkg-config: sqlite3
+// #include <stdlib.h>
+// #include "regexp_extension.h"
+import "C"
+
+import (
+	"regexp"
+	"unsafe"
+)
+
+//export go_register_regexp
+func go_register_regexp(db *C.sqlite3) C.int {
+	rc := C.create_regexp(db)
+	if rc != C.SQLITE_OK {
+		return rc
+	}
+	return C.SQLITE_OK
+}
+
+//export go_regexp
+func go_regexp(ctx *C.sqlite3_context, argc C.int, argv **C.sqlite3_value) {
+	if argc != 2 {
+		msg := C.CString("regexp(): requires exactly 2 arguments: pattern, text")
+		C.result_error(ctx, msg)
+		C.free(unsafe.Pointer(msg))
+		return
+	}
+
+	vPattern := C.value_at(argv, 0)
+	vText := C.value_at(argv, 1)
+
+	cText := (*C.uchar)(C.value_text(vText))
+	cPattern := (*C.uchar)(C.value_text(vPattern))
+
+	if cText == nil || cPattern == nil {
+		C.result_null(ctx)
+		return
+	}
+
+	pattern := C.GoString((*C.char)(unsafe.Pointer(cPattern)))
+	text := C.GoString((*C.char)(unsafe.Pointer(cText)))
+
+	compiled, err := regexp.Compile(pattern)
+	if err != nil {
+		msg := C.CString(err.Error())
+		C.result_error(ctx, msg)
+		C.free(unsafe.Pointer(msg))
+		return
+	}
+
+	if compiled.MatchString(text) {
+		C.result_int(ctx, 1)
+	} else {
+		C.result_int(ctx, 0)
+	}
+}

--- a/extension/regexp_extension.h
+++ b/extension/regexp_extension.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <sqlite3ext.h>
+
+// Helpers exposed to Go via cgo
+sqlite3_value* value_at(sqlite3_value **argv, int idx);
+const unsigned char* value_text(sqlite3_value* v);
+void result_null(sqlite3_context* ctx);
+void result_error(sqlite3_context* ctx, const char* msg);
+void result_int(sqlite3_context* ctx, int v);
+int create_regexp(sqlite3* db);
+
+

--- a/ttmp/2025-08-10/01-sqlite-cgo-so-extension-building.md
+++ b/ttmp/2025-08-10/01-sqlite-cgo-so-extension-building.md
@@ -1,0 +1,79 @@
+Yes — but only if you build the extension as a **shared library** that SQLite can load, not as part of the statically linked `mattn/go-sqlite3` Go binary.
+
+The Go driver’s built-in extensions (like `REGEXP`) exist only inside the Go program’s compiled binary. The stock `sqlite3` CLI can’t “see” them unless you separately compile your code into a `.so`/`.dylib` and load it at runtime using SQLite’s extension loading mechanism.
+
+Here’s how you can make it work:
+
+---
+
+### 1. Write the Extension in C (or Cgo) Form
+
+If your `mattn/go-sqlite3` REGEXP implementation is written in Go, you can:
+
+* Either rewrite it in C so it compiles cleanly as a SQLite loadable extension.
+* Or, use **Cgo** to build a `.so` from Go code, but this is more complex because SQLite extensions expect a C ABI entrypoint.
+
+For example, a simple C extension entrypoint looks like:
+
+```c
+#include <sqlite3ext.h>
+SQLITE_EXTENSION_INIT1
+
+static void regexp_func(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
+    // your REGEXP logic here
+}
+
+int sqlite3_regexp_init(sqlite3 *db, char **pzErrMsg,
+                        const sqlite3_api_routines *pApi) {
+    SQLITE_EXTENSION_INIT2(pApi)
+    sqlite3_create_function(db, "regexp", 2, SQLITE_UTF8, NULL, regexp_func, NULL, NULL);
+    return SQLITE_OK;
+}
+```
+
+---
+
+### 2. Compile It as a Loadable Extension
+
+Example:
+
+```bash
+gcc -fPIC -shared -o regexp.so regexp.c \
+    -I/usr/include/sqlite3
+```
+
+---
+
+### 3. Load It in the Standard SQLite CLI
+
+Inside the SQLite CLI:
+
+```sql
+.load ./regexp
+SELECT 'abc' REGEXP 'a.c';
+```
+
+If `sqlite3` on your system was compiled with `-DSQLITE_ENABLE_LOAD_EXTENSION`, you can do:
+
+```sql
+sqlite> .load ./regexp
+sqlite> SELECT 'hello' REGEXP 'h.llo';
+```
+
+Otherwise, you need to enable it in the CLI first:
+
+```sql
+sqlite> .load ./regexp
+```
+
+---
+
+### Key Points
+
+* The Go driver’s extension code is **inside your Go binary**; the CLI won’t have it unless you extract and compile it as a standalone `.so`.
+* You **cannot** just “point” the CLI to your Go program and expect it to pick up the REGEXP — you must repackage it in SQLite’s shared library extension format.
+* Once built as `.so` (Linux) or `.dylib` (macOS), you can `.load` it in *any* SQLite CLI or any SQLite instance that supports extension loading.
+
+---
+
+If you want, I can walk you through taking your **exact Go-based REGEXP implementation** from `mattn/go-sqlite3` and building it as a `.so` so it works in `sqlite3`. That’s slightly tricky because of Go’s C ABI rules, but doable. Would you like me to detail that build process?

--- a/ttmp/2025-08-10/02-how-to-build-a-so-golang-sqlite-extension.md
+++ b/ttmp/2025-08-10/02-how-to-build-a-so-golang-sqlite-extension.md
@@ -1,0 +1,237 @@
+## Building a SQLite Loadable Extension (.so/.dylib) from Go code
+
+This guide documents how we added a SQLite loadable extension for `REGEXP` to `go-sqlite-regexp`, what pitfalls we hit, and a clean recipe to repeat next time.
+
+The end result is a shared library you can load in the SQLite CLI or any embedding that supports extension loading:
+
+- Linux: `./regexp.so`
+- macOS: `./regexp.dylib`
+
+Load and use in the `sqlite3` shell:
+
+```sql
+.load ./regexp
+SELECT 'hello' REGEXP 'h.llo';   -- 1
+SELECT regexp('h.llo','hello');  -- 1
+```
+
+### Overview
+
+- We keep our Go logic (RE2 matching) in Go, but expose it as a SQLite function through cgo.
+- We implement the required SQLite extension entrypoint (`sqlite3_<name>_init`) in C, not Go, because of macro usage.
+- We compile with `-buildmode=c-shared` to produce a shared object.
+
+### Files Added
+
+- `extension/regexp_extension.c`: C entrypoint, wrappers for SQLite macros, trampoline into Go.
+- `extension/regexp_extension.h`: C declarations for helpers exposed to Go.
+- `extension/regexp_extension.go`: Go implementation of `regexp(pattern, text)` wired to SQLite via cgo.
+- `extension/main_dummy.go`: Tiny `main()` required by `-buildmode=c-shared`.
+
+### Key C code
+
+```1:30:go-sqlite-regexp/extension/regexp_extension.c
+#include <sqlite3ext.h>
+#include <stdlib.h>
+#include "regexp_extension.h"
+SQLITE_EXTENSION_INIT1
+
+// Forward declarations for Go
+extern void go_regexp(sqlite3_context *ctx, int argc, sqlite3_value **argv);
+extern int go_register_regexp(sqlite3* db);
+
+// Helper to index argv
+sqlite3_value* value_at(sqlite3_value **argv, int idx) { return argv[idx]; }
+const unsigned char* value_text(sqlite3_value* v) { return sqlite3_value_text(v); }
+void result_null(sqlite3_context* ctx) { sqlite3_result_null(ctx); }
+void result_error(sqlite3_context* ctx, const char* msg) { sqlite3_result_error(ctx, msg, -1); }
+void result_int(sqlite3_context* ctx, int v) { sqlite3_result_int(ctx, v); }
+
+// C-visible trampoline that calls into Go implementation
+static void call_go_regexp(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
+    go_regexp(ctx, argc, argv);
+}
+
+// Helper to register the function with SQLite
+int create_regexp(sqlite3* db) {
+    return sqlite3_create_function(db, "regexp", 2, SQLITE_UTF8, NULL, call_go_regexp, NULL, NULL);
+}
+
+int sqlite3_regexp_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi) {
+    SQLITE_EXTENSION_INIT2(pApi);
+    return go_register_regexp(db);
+}
+```
+
+Notes:
+- `SQLITE_EXTENSION_INIT1/2` macros must be used in C, not Go.
+- We expose small helper functions so Go can call into SQLite C API cleanly (macros are not callable from cgo).
+
+### Key Go code
+
+```1:58:go-sqlite-regexp/extension/regexp_extension.go
+package main
+
+// #cgo pkg-config: sqlite3
+// #include <stdlib.h>
+// #include "regexp_extension.h"
+import "C"
+
+import (
+    "regexp"
+    "unsafe"
+)
+
+//export go_register_regexp
+func go_register_regexp(db *C.sqlite3) C.int {
+    rc := C.create_regexp(db)
+    if rc != C.SQLITE_OK {
+        return rc
+    }
+    return C.SQLITE_OK
+}
+
+//export go_regexp
+func go_regexp(ctx *C.sqlite3_context, argc C.int, argv **C.sqlite3_value) {
+    if argc != 2 {
+        msg := C.CString("regexp(): requires exactly 2 arguments: pattern, text")
+        C.result_error(ctx, msg)
+        C.free(unsafe.Pointer(msg))
+        return
+    }
+
+    vPattern := C.value_at(argv, 0)
+    vText := C.value_at(argv, 1)
+
+    cText := (*C.uchar)(C.value_text(vText))
+    cPattern := (*C.uchar)(C.value_text(vPattern))
+
+    if cText == nil || cPattern == nil {
+        C.result_null(ctx)
+        return
+    }
+
+    pattern := C.GoString((*C.char)(unsafe.Pointer(cPattern)))
+    text := C.GoString((*C.char)(unsafe.Pointer(cText)))
+
+    compiled, err := regexp.Compile(pattern)
+    if err != nil {
+        msg := C.CString(err.Error())
+        C.result_error(ctx, msg)
+        C.free(unsafe.Pointer(msg))
+        return
+    }
+
+    if compiled.MatchString(text) {
+        C.result_int(ctx, 1)
+    } else {
+        C.result_int(ctx, 0)
+    }
+}
+```
+
+Notes:
+- The SQLite REGEXP operator uses the order `(text REGEXP pattern)`, but the function form is conventionally `regexp(pattern, text)`. We implement the function in that order and the `operator` becomes correct automatically.
+- We use Go’s `regexp` (RE2) for deterministic performance.
+
+### Makefile targets
+
+```74:84:go-sqlite-regexp/Makefile
+# Build loadable SQLite extension (.so/.dylib) using c-shared
+# Output goes to dist/regexp.$(EXT)
+so: so-linux
+
+so-linux:
+	@echo "Building SQLite loadable extension for Linux (.so)..."
+	@CGO_ENABLED=1 go build -buildmode=c-shared -o regexp.so ./extension
+
+so-darwin:
+	@echo "Building SQLite loadable extension for macOS (.dylib)..."
+	@CGO_ENABLED=1 go build -buildmode=c-shared -o regexp.dylib ./extension
+```
+
+Build with:
+
+- Linux: `make so-linux` → `./regexp.so`
+- macOS: `make so-darwin` → `./regexp.dylib`
+
+### Why split C and Go?
+
+- The SQLite extension ABI expects a C symbol `sqlite3_<name>_init` and relies on macros `SQLITE_EXTENSION_INIT1/2`. These macros can’t be invoked from Go.
+- Initially we tried to use these macros inside the cgo preamble of a Go file, which led to errors like “could not determine what C.SQLITE_EXTENSION_INIT2 refers to” and “multiple definition of `sqlite3_regexp_init`”. Moving the entrypoint to a separate `.c` file resolves this cleanly.
+- Some SQLite API utilities are macros (e.g., `sqlite3_result_int`, `sqlite3_value_text`). We wrapped them in real C functions so Go can call them.
+
+### Common pitfalls we encountered
+
+1) Macro calls from Go
+- Symptom: `call of non-function C.sqlite3_result_error`
+- Fix: Wrap macro calls in C functions and call those from Go.
+
+2) `SQLITE_EXTENSION_INIT2` in Go preamble
+- Symptom: `could not determine what C.SQLITE_EXTENSION_INIT2 refers to`
+- Fix: Implement the extension entrypoint in C and call a Go-exported `go_register_regexp` from there.
+
+3) Multiple definitions during linking
+- Symptom: `multiple definition of sqlite3_regexp_init` or `sqlite3_api`
+- Cause: Including the same C code twice (once via preamble, once via separate C file).
+- Fix: Keep the macro-based entrypoint only in the C file; in Go, include only the header (`#include "regexp_extension.h"`).
+
+4) Missing C standard headers
+- Symptom: `could not determine what C.free refers to`
+- Fix: Add `#include <stdlib.h>` in the cgo preamble that uses `C.free`.
+
+5) Argument order confusion
+- We validated with sqlite3 CLI that the function form should be `regexp(pattern, text)` to make the operator `text REGEXP pattern` behave intuitively. We adjusted argument extraction accordingly and verified with tests.
+
+### End-to-end test
+
+Non-interactive CLI test on Linux:
+
+```bash
+sqlite3 -batch ":memory:" -cmd ".load ./regexp" \
+  "SELECT regexp('h.llo','hello');" \
+  "SELECT regexp('^h.*o$','hello');" \
+  "SELECT regexp('d','abc');" \
+  "SELECT 'hello' REGEXP 'h.llo';" \
+  "SELECT 'hello' REGEXP '^h.*o$';" \
+  "SELECT 'abc' REGEXP 'd';"
+# Expected output:
+# 1
+# 1
+# 0
+# 1
+# 1
+# 0
+```
+
+### Clean recipe to repeat next time
+
+1) Create `extension/regexp_extension.c` with:
+- `SQLITE_EXTENSION_INIT1/2`
+- `sqlite3_<name>_init` entrypoint that calls an exported Go registration function
+- A trampoline that calls an exported Go function for the SQL callback
+- Small C wrappers for SQLite API macros you need to call from Go
+
+2) Create `extension/regexp_extension.h` declaring the C wrappers used from Go.
+
+3) Create `extension/regexp_extension.go`:
+- cgo includes the header and `stdlib.h` for `C.free`
+- `//export go_register_regexp` that calls `create_regexp`
+- `//export go_regexp` implementing the function logic (compile RE2, match, set int result)
+
+4) Add `extension/main_dummy.go` with an empty `main()` to satisfy `-buildmode=c-shared`.
+
+5) Add Make targets:
+- `go build -buildmode=c-shared -o regexp.so ./extension`
+- Optionally, a macOS target outputting `regexp.dylib`
+
+6) Test in the sqlite3 CLI with `.load ./regexp` and sample queries.
+
+### Future improvements
+
+- Add Windows build target (`.dll`) via `-buildmode=c-shared` and appropriate sqlite linkage.
+- Add simple CI matrix to produce `.so` and `.dylib` artifacts.
+- Add caching to the extension version as in the Go library (today it recompiles regex per call). A small LRU in Go could mirror the package cache.
+- Add parameter validation and clearer error messages in SQL.
+
+


### PR DESCRIPTION
- Introduces new build targets in the Makefile for creating 
  loadable SQLite extensions as shared objects (.so for Linux, 
  .dylib for macOS).
- Adds necessary C and Go files to implement the SQLite REGEXP 
  function as a shared library.
- Updates README to include instructions on how to build and 
  load the extension in the SQLite CLI.
- Provides detailed documentation on the building process 
  and common pitfalls encountered.